### PR TITLE
Interpret source maps for coverage results

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ module.exports = function (file, opts) {
     if (!opts) opts = {};
     var outputFn = opts.output || 'console.log';
     
-    var output = through();
     var expected = [];
     
     var chunks = [];

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = function (file, opts) {
         || node.type === 'VariableDeclaration')
         && node.parent.type !== 'ForStatement'
         && node.parent.type !== 'ForInStatement') {
-            var s = '{ __coverageWrap(' + index + ');' + node.source() + '}';
+            var s = '{ __coverageWrap(' + index + ');' + node.source() + '\n}';
             if (node.parent.type === 'IfStatement') {
                 node.update(s);
             }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "coverify": "bin/cmd.js"
   },
   "dependencies": {
+    "convert-source-map": "~1.0.0",
     "falafel": "~0.3.1",
     "minimist": "~0.0.5",
+    "source-map": "~0.4.2",
     "split": "~0.2.10",
     "stream-combiner": "~0.0.2",
     "through": "~2.3.4"

--- a/parse.js
+++ b/parse.js
@@ -32,7 +32,13 @@ module.exports = function (cb) {
         }, []);
         
         var missed = Object.keys(files).reduce(function (acc, file) {
+            var seen = {};
             acc[file] = files[file].filter(Boolean).filter(function (mr) {
+                var key = mr.join('-');
+                if (seen.hasOwnProperty(key)) {
+                    return false;
+                }
+                seen[key] = true;
                 return !ranges.some(function (rr) {
                     return (mr[0] > rr[0] && mr[1] < rr[1])
                         || (mr[0] === rr[0] && mr[1] < rr[1])

--- a/parse.js
+++ b/parse.js
@@ -16,7 +16,7 @@ module.exports = function (cb) {
             var file = m[1], ranges = m[2];
             if (/^"/.test(file) && /"$/.test(file)) file = JSON.parse(file);
             files[file] = JSON.parse(ranges);
-            original[file] = JSON.parse(ranges);
+            original[file] = JSON.parse(ranges).filter(Boolean);
         }
         else if (m = /^COVERED\s+("[^"]+"|\S+)\s+(\S+)/.exec(line)) {
             var file = m[1], index = m[2];

--- a/test/ok-trailing-comment.js
+++ b/test/ok-trailing-comment.js
@@ -1,0 +1,2 @@
+1
+// hello world!

--- a/test/run.sh
+++ b/test/run.sh
@@ -2,6 +2,9 @@
 browserify test/ok.js | node | bin/cmd.js \
     || (echo FAIL test/ok.js; exit 1) || exit 1
 
+browserify test/ok-trailing-comment.js \
+    || (echo FAIL test/ok-trailing-comment.js; exit 1) || exit 1
+
 browserify test/fail.js | node | bin/cmd.js \
     && echo FAIL test/fail.js && exit 1
 


### PR DESCRIPTION
This is an experimental attempt at https://github.com/substack/coverify/issues/16#issuecomment-76259725. If a source map is present, all coverage ranges are converted to their original positions in the source. If a range does not have a valid source map translation, it is discarded. I'm not convinced this will lead to complete results (and varies on the generator of the source map). Thoughts?

I've tried this change with both Babelify and Reactify, and it seems to produce useful output.