### PR TITLE
Convert Windows paths to forward slashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var falafel = require('falafel');
 var through = require('through2');
 var sourceMap = require('source-map');
 var convertSourceMap = require('convert-source-map');
+var slash = require('slash');
 
 module.exports = function (file, opts) {
     if (typeof file === 'object') {
@@ -40,7 +41,7 @@ module.exports = function (file, opts) {
         var bodySourceMap = convertSourceMap.fromSource(body);
         if (bodySourceMap && bodySourceMap.sourcemap.mappings) {
             bodySourceMap = new sourceMap.SourceMapConsumer(bodySourceMap.sourcemap);
-            origBody = bodySourceMap.sourceContentFor(file);
+            origBody = bodySourceMap.sourceContentFor(slash(file));
             function originalLoc (loc) {
                 var pos = bodySourceMap.originalPositionFor(loc);
                 if (pos.line && pos.column) {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "convert-source-map": "^1.1.0",
     "falafel": "^1.0.1",
     "minimist": "^1.1.1",
+    "slash": "^1.0.0",
     "source-map": "~0.4.2",
     "split2": "^0.2.1",
     "stream-combiner2": "^1.0.2",


### PR DESCRIPTION
mozilla/source-map#91:
> The reason we use / is because a source map's sources are URLs and URLs use /.

This was preventing me from using Coverify with Babelify.